### PR TITLE
Return both the response and the body on non-200 errors.

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -103,7 +103,7 @@ function resolveResponse(deferred, api, req) {
         request(req, resolveResponse(deferred, api, req));
       }, api));
     } else if (res.statusCode != 200) {
-      deferred.reject(body);
+      deferred.reject({res: res, body: body});
     } else {
       deferred.resolve(body);
     }


### PR DESCRIPTION
We need more info about the response in these cases.
