### PR TITLE
Force correct handling of query string parameters.

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -1,6 +1,7 @@
 var request = require('request');
 var q = require('q');
 var _ = require('underscore');
+var querystring = require('querystring');
 
 var api = exports = module.exports = {};
 var tokenPromise = null;
@@ -15,10 +16,14 @@ api.defaultConfiguration = function() {
   this.set('maxLimit', 500);
 };
 
-api.urlFor = function(resource, id) {
+api.urlFor = function(resource, id, parameters) {
   var url = this.settings.url + '/' + resource;
   if (id) {
     url = url + '/' + id;
+  }
+
+  if (parameters) {
+    url = url + '?' + querystring.stringify(parameters);
   }
 
   return url;
@@ -51,7 +56,7 @@ api.get = function(resource, id, parameters) {
   }
 
   return this.getToken().then(_.bind(function(token) {
-    var req = {url: this.urlFor(resource, id), qs: parameters, headers: {'Authorization': 'Bearer ' + token}, json: true};
+    var req = {url: this.urlFor(resource, id, parameters), headers: {'Authorization': 'Bearer ' + token}, json: true};
 
     request(req, resolveResponse(deferred, this, req));
 
@@ -66,7 +71,7 @@ api.getResult = function(resource, id, parameters) {
 api.index = function(resource, parameters) {
   return this.getToken().then(_.bind(function(token) {
     var deferred = q.defer();
-    var req = {url: this.urlFor(resource), qs: parameters, headers: {'Authorization': 'Bearer ' + token}, json: true};
+    var req = {url: this.urlFor(resource, null, parameters), headers: {'Authorization': 'Bearer ' + token}, json: true};
 
     request(req, resolveResponse(deferred, this, req));
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tol-api",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "TraderOnline api client",
   "dependencies":  {
     "q": "~1.0",


### PR DESCRIPTION
mikeal/request does not appear to handle array parameters the same way
as default node.js querystring.stringify.

Given the parameters {foo: [1, 2, 3]}, it generates the querystring
foo[0]=1&foo[1]=2&foo[2]=3 insteadd of foo=1&foo=2&foo=3.

Our API expects the latter, so we need to use querystring.stringify to
handle this and build the full url ourselves.
