### PR TITLE
Add support for POST, allow all 2xx and 3xx replies, and return full response (with headers and such).

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -45,7 +45,7 @@ api.getToken = function() {
     );
   }
 
-  return tokenPromise.get('access_token');
+  return tokenPromise.get('body').get('access_token');
 };
 
 api.get = function(resource, id, parameters) {
@@ -65,7 +65,7 @@ api.get = function(resource, id, parameters) {
 };
 
 api.getResult = function(resource, id, parameters) {
-  return this.get(resource, id, parameters).get('result');
+  return this.get(resource, id, parameters).get('body').get('result');
 };
 
 api.index = function(resource, parameters) {
@@ -83,12 +83,12 @@ api.indexAll = function(resource, parameters) {
   var promises = [];
   promises.push(this.index(resource, _.extend({}, parameters, {offset: 0, limit: this.settings.maxLimit})));
   return promises[0].then(_.bind(function(firstPage) {
-    for (var offset = this.settings.maxLimit; offset < firstPage.pagination.total; offset += this.settings.maxLimit) {
+    for (var offset = this.settings.maxLimit; offset < firstPage.body.pagination.total; offset += this.settings.maxLimit) {
       promises.push(this.index(resource, _.extend({}, parameters, {offset: offset, limit: this.settings.maxLimit})));
     }
 
     return q.all(promises).then(function(pages) {
-      return _.flatten(_.pluck(pages, 'result'), true);
+      return _.flatten(_.pluck(_.pluck(pages, 'body'), 'result'), true);
     });
   }, this));
 };
@@ -132,7 +132,7 @@ function resolveResponse(deferred, api, req) {
     } else if (res.statusCode >= 400) {
       deferred.reject({res: res, body: body});
     } else {
-      deferred.resolve(body);
+      deferred.resolve({res: res, body: body});
     }
   };
 }


### PR DESCRIPTION
The API client needs to support the POST method (PUT/DELETE/HEAD can come later).  This adds a new method for supporting post actions with the typical JSON body.

With the new POST method, 200 is not the only type of successful response code.  We really should treat all 2xx and 3xx replies as a "success" and not reject the promise.

Finally, as a nice backwards-compatibility breaker, the promise for the index/get/post methods now resolves to a `{body: "...", res: {...}}` object rather than just the body.  We need access to the headers of the response, and that gives us the access we need.  `getResult` and `indexAll` are unchanged as they are purposefully just trying to access the data.

_Pull Request commit modified by @nubs._
