### PR TITLE
add appName support while using jwt token

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -14,6 +14,7 @@ api.init = function() {
   this.tokenPromise = null;
   this.refreshToken = null;
   this.jwt = null;
+  this.appName = null;
   this.settings = {};
   this.defaultConfiguration();
 };
@@ -59,8 +60,8 @@ api.urlFor = function(resource, id, parameters) {
 api.getTokens = function() {
   var self = this;
   if (!this.tokenPromise) {
-    if (this.jwt) {
-      this.tokenPromise = this.settings.tokenFetcher(null, this.jwt).then(function(tokens) {
+    if (this.jwt && this.appName) {
+      this.tokenPromise = this.settings.tokenFetcher(null, this.jwt, this.appName).then(function(tokens) {
         tokens.jwt = self.jwt;
         return tokens;
       });
@@ -115,6 +116,17 @@ api.setTokens = function(tokens) {
  */
 api.setJwt = function(jwt) {
   this.jwt = jwt
+};
+
+/**
+ * Sets this clients jwt app name which can be used to get a new access_token depending on app
+ *
+ * @param {string} appName - The app name to set
+ *
+ * @returns void
+ */
+api.setAppName = function(appName) {
+  this.appName = appName
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tol-api",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "TraderOnline api client",
   "dependencies": {
     "q": "~1.0",


### PR DESCRIPTION
add appName support while using jwt token
This allows Unified dealer center to figure out which app name it can use depending on dealer id.