### PR TITLE
ABOAT-1480 - User authentication for Neb 2

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -599,6 +599,9 @@ function parseTokenResponse(res) {
     if (res.body.refresh_token) {
       tokens.refresh_token = res.body.refresh_token;
     }
+    if (res.body.expires_in) {
+      tokens.expires_in = res.body.expires_in;
+    }
 
     return tokens;
   } else {


### PR DESCRIPTION
Added expires_in to token response as it is required for PHP library to refresh expired tokens

[https://traderinteractive.atlassian.net/browse/ABOAT-1480](https://traderinteractive.atlassian.net/browse/ABOAT-1480)